### PR TITLE
Ansible Deployment for Windows

### DIFF
--- a/deployments/ansible/roles/collector/README.md
+++ b/deployments/ansible/roles/collector/README.md
@@ -4,6 +4,16 @@ Ansible role that installs Splunk OpenTelemetry Connector configured to
 collect metrics, traces and logs from Linux machines and send data to [Splunk 
 Observability Cloud](https://www.splunk.com/en_us/observability.html). 
 
+## Windows
+Currently, the following Windows versions are supported:
+Ansible requires PowerShell 3.0 or newer and atleast .NET4.0 to be installed on Windows host.
+A WinRM listner should be created and activeted. 
+For setting up Windows Host Refer:[Ansible Docs](https://docs.ansible.com/ansible/latest/user_guide/windows_setup.html).
+
+- Windows Server 2012 64-bit
+- Windows Server 2016 64-bit
+- Windows Server 2019 64-bit
+
 ## Prerequisites
 
 - [Splunk Access Token](https://docs.splunk.com/Observability/admin/authentication-tokens/org-tokens.html#admin-org-tokens)
@@ -22,6 +32,8 @@ how to use the role in a playbook with minimal required configuration:
 ```yaml
 - name: Install Splunk OpenTelemetry Connector
   hosts: all
+  #For Windows "become: yes" will raise error.
+  #"The Powershell family is incompatible with the sudo become plugin" Remove "become: yes" tag to run on Windows
   become: yes
   tasks:
     - name: "Include splunk_otel_collector"
@@ -63,20 +75,25 @@ how to use the role in a playbook with minimal required configuration:
   config, e.g. `./custom_collector_config.yaml`. (**default:** `""` meaning 
   that nothing will be copied and existing `splunk_otel_collector_config` will be used)
 
-- `splunk_bundle_dir`: The path to the [Smart Agent bundle directory](
+- `collector_path_win`: Default path of Splunk-otel-collector in windows 
+  (**default:** `C:\\Program Files\Splunk\OpenTelemetry Collector\`)
+
+- `splunk_bundle_dir` & : The path to the [Smart Agent bundle directory](
   https://github.com/signalfx/splunk-otel-collector/blob/main/internal/extension/smartagentextension/README.md).
   The default path is provided by the collector package. If the specified path
   is changed from the default value, the path should be an existing directory
   on the node. The `SPLUNK_BUNDLE_DIR` environment variable will be set to
   this value for the collector service.  (**default:**
-  `/usr/lib/splunk-otel-collector/agent-bundle`)
+  `/usr/lib/splunk-otel-collector/agent-bundle` For Windows `${collector_path_win}\agent-bundle`)
 
-- `splunk_collectd_dir`: The path to the collectd config directory for the
+- `splunk_collectd_dir` & `splunk_collectd_dir_win`: The path to the collectd config directory for the
   Smart Agent bundle. The default path is provided by the collector package.
   If the specified path is changed from the default value, the path should be
   an existing directory on the node. The `SPLUNK_COLLECTD_DIR` environment
-  variable will be set to this value for the collector service.  (**default:**
-  `/usr/lib/splunk-otel-collector/agent-bundle`)
+  variable will be set to this value for the collector service. 
+  (**default:** `/usr/lib/splunk-otel-collector/agent-bundle`
+  For Windows `${splunk_bundle_dir_win}\run\collectd`)
+
 
 - `splunk_service_user` and `splunk_service_group` (Linux only): Set the user/group
   ownership for the collector service. The user/group will be created if they
@@ -110,3 +127,26 @@ how to use the role in a playbook with minimal required configuration:
   remote hosts. Can be used to submit a custom fluentd config,
   e.g. `./custom_fluentd_config.conf`. (**default:** `""` meaning 
   that nothing will be copied and existing `splunk_fluentd_config` will be used)
+
+- `collector_config_source_win`: Source path to the collector config YAML file. This file will 
+  be copied to the $collector_config_dest path on the node. See the source attribute of the file 
+  resource for supported value types. The default source file is provided by the collector package.
+  (**default:** `C:\\Program Files\Splunk\OpenTelemetry Collector\agent_config.yaml`)
+
+- `collector_config_dest_win`: Destination path of the collector config file on the node. 
+  The SPLUNK_CONFIG environment variable will be set with this value for the collector service.
+  (**default:** `C:\\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml`)
+
+- `win_fluentd_config_source`: Source path to the fluentd config file. 
+  (**default:** `${collector_path_win}\\fluentd\\td-agent.conf`)
+  
+- `win_fluentd_config_dest`: On Windows, the path will always be set to default
+  (**default:** `%SYSTEMDRIVE%\opt\td-agent\etc\td-agent\td-agent.conf`)
+
+- `win_td-agent_version`: Version of td-agent (fluentd package) that will be 
+  installed in Windows distro (`4.1.1`)
+
+- `win_otel_version`: Version of splunk-otel-collector that will be installed in
+  Windows distri(`0.31.0`) 
+
+ 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -53,11 +53,11 @@ splunk_collectd_dir_win: ${splunk_bundle_dir_win}\run\collectd
 
 collector_config_source_win:  ${collector_path_win}\agent_config.yaml
 
-collector_config_dest_win: C:\\PeogramData\Splunk\OpenTelemetry Collector\agent_config.yaml
+collector_config_dest_win: C:\PeogramData\Splunk\OpenTelemetry Collector\agent_config.yaml
 
-collector_path_win: C:\\Program Files\Splunk\OpenTelemetry Collector
+collector_path_win: C:\Program Files\Splunk\OpenTelemetry Collector
 
-win_fluentd_config_source: ${collector_path_win}\\fluentd\\td-agent.conf
+win_fluentd_config_source: ${collector_path_win}\fluentd\td-agent.conf
 # On Windows, the path will always be set to %SYSTEMDRIVE%\opt\td-agent\etc\td-agent\td-agent.conf
 win_fluentd_config_dest: ""
 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -65,7 +65,7 @@ package_stage: release
 # Splunk-otel-collector Windows MSI version
 win_otel_version: 0.31.0
 # FluentD Windows Version
-win_td-agent_version: 4.1.1
+win_td_agent_version: 4.1.1
 
 # Path to set ENV in Windows
 registry_key: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -34,3 +34,38 @@ splunk_fluentd_config_source: ""
 
 agent_bundle_dir: /usr/lib/splunk-otel-collector/agent-bundle
 splunk_collectd_dir: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+
+# default vars For Windows family
+
+splunk_api_url: https://api.${splunk_realm}.signalfx.com
+
+splunk_ingest_url:  https://ingest.${splunk_realm}.signalfx.com
+
+splunk_trace_url: ${splunk_ingest_url}/v2/trace
+
+splunk_hec_url: ${splunk_ingest_url}/v1/log
+
+splunk_hec_token: $splunk_access_token
+
+splunk_bundle_dir_win: ${collector_path_win}\agent-bundle
+
+splunk_collectd_dir_win: ${splunk_bundle_dir_win}\run\collectd
+
+collector_config_source_win:  ${collector_path_win}\agent_config.yaml
+
+collector_config_dest_win: C:\\PeogramData\Splunk\OpenTelemetry Collector\agent_config.yaml
+
+collector_path_win: C:\\Program Files\Splunk\OpenTelemetry Collector
+
+win_fluentd_config_source: ${collector_path_win}\\fluentd\\td-agent.conf
+# On Windows, the path will always be set to %SYSTEMDRIVE%\opt\td-agent\etc\td-agent\td-agent.conf
+win_fluentd_config_dest: ""
+
+package_stage: release
+# Splunk-otel-collector Windows MSI version
+win_otel_version: 0.31.0
+# FluentD Windows Version
+win_td-agent_version: 4.1.1
+
+# Path to set ENV in Windows
+registry_key: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -53,7 +53,7 @@ splunk_collectd_dir_win: ${splunk_bundle_dir_win}\run\collectd
 
 collector_config_source_win:  ${collector_path_win}\agent_config.yaml
 
-collector_config_dest_win: C:\PeogramData\Splunk\OpenTelemetry Collector\agent_config.yaml
+collector_config_dest_win: C:\ProgramData\Splunk\OpenTelemetry Collector\agent_config.yaml
 
 collector_path_win: C:\Program Files\Splunk\OpenTelemetry Collector
 

--- a/deployments/ansible/roles/collector/defaults/main.yml
+++ b/deployments/ansible/roles/collector/defaults/main.yml
@@ -37,9 +37,9 @@ splunk_collectd_dir: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
 
 # default vars For Windows family
 
-splunk_api_url: https://api.${splunk_realm}.signalfx.com
+splunk_api_url: https://api.us0.signalfx.com
 
-splunk_ingest_url:  https://ingest.${splunk_realm}.signalfx.com
+splunk_ingest_url:  https://ingest.us0.signalfx.com
 
 splunk_trace_url: ${splunk_ingest_url}/v2/trace
 

--- a/deployments/ansible/roles/collector/handlers/main.yml
+++ b/deployments/ansible/roles/collector/handlers/main.yml
@@ -20,3 +20,15 @@
     name: splunk-otel-collector
     state: restarted
   listen: "restart splunk-otel-collector"
+
+- name: Restart Splunk OpenTelemetry Collector for windows
+  ansible.windows.win_service:
+    name: splunk-otel-collector
+    state: restarted
+  listen: "restart windows splunk-otel-collector"
+
+- name: Restart Splunk td-agent for windows
+  ansible.windows.win_service:
+    name: fluentdwinsvc
+    state: restarted
+  listen: "restart windows fluentdwinsvc"

--- a/deployments/ansible/roles/collector/meta/main.yml
+++ b/deployments/ansible/roles/collector/meta/main.yml
@@ -22,3 +22,4 @@ galaxy_info:
         - buster
         - stretch
     - name: Amazon
+    - name: Windows

--- a/deployments/ansible/roles/collector/tasks/main.yml
+++ b/deployments/ansible/roles/collector/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+
+- name: Define acceptable distros For splunk-otel-collector
+  set_fact:
+    debian_distro: ['Debian', 'Ubuntu']
+    rhel_distro: ['CentOS', 'RedHat', 'Red Hat Enterprise Linux', 'Amazon']
+    windows_distro: ['Windows']
+    cacheable: true
+
 - name: Make sure access token is provided
   ansible.builtin.assert:
     that: "'{{ splunk_access_token }}'"
@@ -6,8 +14,14 @@
 
 - name: Make sure host OS is supported
   ansible.builtin.assert:
-    that: ansible_os_family in ["Debian", "RedHat"]
+    that: ansible_os_family in ["Debian", "RedHat", "Windows"]
     fail_msg: "{{ ansible_os_family }} OS family currently is not supported"
 
 - name: Linux deployment
   ansible.builtin.import_tasks: linux_install.yml
+  when: not ansible_os_family in windows_distro
+
+# Windows Deplyment using MSI 
+- name: Windows deployment
+  ansible.builtin.import_tasks: win_install.yml
+  when: ansible_os_family in windows_distro

--- a/deployments/ansible/roles/collector/tasks/main.yml
+++ b/deployments/ansible/roles/collector/tasks/main.yml
@@ -1,27 +1,41 @@
 ---
 
-- name: Define acceptable distros For splunk-otel-collector
-  set_fact:
-    debian_distro: ['Debian', 'Ubuntu']
-    rhel_distro: ['CentOS', 'RedHat', 'Red Hat Enterprise Linux', 'Amazon']
-    windows_distro: ['Windows']
-    cacheable: true
+# splunk-otel-collector and FluentD Windows installation using msi.
 
-- name: Make sure access token is provided
-  ansible.builtin.assert:
-    that: "'{{ splunk_access_token }}'"
-    fail_msg: splunk_access_token variable must be provided
+- name: Set Windows packages sources
+  ansible.builtin.set_fact:
+    windows_base_url: https://dl.signalfx.com
+    win_otel_msi: splunk-otel-collector-{{win_otel_version}}-amd64.msi
+    td_agent_base_url: http://packages.treasuredata.com.s3.amazonaws.com
+    win_fluentd_msi: td-agent-{{win_td_agent_version}}-x64.msi
 
-- name: Make sure host OS is supported
-  ansible.builtin.assert:
-    that: ansible_os_family in ["Debian", "RedHat", "Windows"]
-    fail_msg: "{{ ansible_os_family }} OS family currently is not supported"
+# creating Temp dir for downloading MSI packages
+- name: Create directory structure
+  ansible.windows.win_file:
+    path: C:\Users\Temp
+    state: directory
 
-- name: Linux deployment
-  ansible.builtin.import_tasks: linux_install.yml
-  when: not ansible_os_family in windows_distro
+- name: Install Splunk OpenTelemetry Collector with msi package manager for Windows
+  ansible.builtin.import_tasks: otel_win_install.yml
+  when: ansible_os_family == "Windows"
 
-# Windows Deplyment using MSI 
-- name: Windows deployment
-  ansible.builtin.import_tasks: win_install.yml
-  when: ansible_os_family in windows_distro
+- name: Set Windows Registry values
+  ansible.builtin.import_tasks: otel_win_reg.yml
+  when: ansible_os_family == "Windows"
+
+- name: Push custom config for Splunk OTel Collector, if provided
+  ansible.builtin.copy:
+    src: "{{collector_config_source_win}}"
+    dest: "{{collector_config_dest_win}}"
+  when: splunk_otel_collector_config_source != ''
+  notify: "restart windows splunk-otel-collector"
+
+- name: Install Splunk OpenTelemetry Collector with yum package manager
+  ansible.builtin.import_tasks: win_fluent_install.yml
+  when: install_fluentd
+
+# Removing Temp directory
+- name: Remove directory structure
+  ansible.windows.win_file:
+    path: C:\Users\Temp
+    state: absent

--- a/deployments/ansible/roles/collector/tasks/otel_win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/otel_win_install.yml
@@ -1,0 +1,26 @@
+
+# Download msi package manager for Windows  
+
+- name: Get splunk-otel-collctor for windows
+  ansible.windows.win_get_url:
+    url: "{{windows_base_url}}/splunk-otel-collector/msi/{{package_stage}}/{{win_otel_msi}}"
+    dest: C:\Users\{{win_otel_msi}}
+  register: msi_package_download
+
+# Check for existing splunk-otel-collector Installation
+- name: Check if splunk-otel-collector service is installed
+  ansible.windows.win_service:
+    name: splunk-otel-collector
+  register: service_info
+
+# Uninstall existing splunk-otel-collector service
+- name: Delete previous splunk-otel-collector service if exist
+  ansible.windows.win_service:
+    name: splunk-otel-collector
+    state: absent
+  when: service_info.exists
+
+- name: install splunk-otel-collector-msi
+  ansible.windows.win_package:
+    path:  C:\Users\{{win_otel_msi}}
+    state: present

--- a/deployments/ansible/roles/collector/tasks/otel_win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/otel_win_install.yml
@@ -4,7 +4,7 @@
 - name: Get splunk-otel-collctor for windows
   ansible.windows.win_get_url:
     url: "{{windows_base_url}}/splunk-otel-collector/msi/{{package_stage}}/{{win_otel_msi}}"
-    dest: C:\Users\{{win_otel_msi}}
+    dest: C:\Users\Temp\{{win_otel_msi}}
   register: msi_package_download
 
 # Check for existing splunk-otel-collector Installation
@@ -22,5 +22,5 @@
 
 - name: install splunk-otel-collector-msi
   ansible.windows.win_package:
-    path:  C:\Users\{{win_otel_msi}}
+    path:  C:\Users\Temp\{{win_otel_msi}}
     state: present

--- a/deployments/ansible/roles/collector/tasks/otel_win_reg.yml
+++ b/deployments/ansible/roles/collector/tasks/otel_win_reg.yml
@@ -1,0 +1,110 @@
+---
+
+- name: Create registry path for collector
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_ACCESS_TOKEN
+    data: "{{splunk_access_token}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_REALM
+    data: "{{splunk_realm}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_CONFIG
+    data: "{{collector_config_dest_win}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_API_URL
+    data: "{{splunk_api_url}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_BALLAST_SIZE_MIB
+    data: "{{splunk_ballast_size_mib}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_BUNDLE_DIR
+    data: "{{splunk_bundle_dir_win}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_COLLECTD_DIR
+    data: "{{splunk_collectd_dir_win}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_HEC_TOKEN
+    data: "{{splunk_hec_token}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_HEC_URL
+    data: "{{splunk_hec_url}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_INGEST_URL
+    data: "{{splunk_ingest_url}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_MEMORY_TOTAL_MIB
+    data: "{{splunk_memory_total_mib}}"
+    type: string
+
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: SPLUNK_TRACE_URL
+    data: "{{splunk_trace_url}}"
+    type: string
+    
+- name: Set registry values
+  ansible.windows.win_regedit:
+    path: "{{registry_key}}"
+    state: present
+    name: ExePath
+    data: "{{collector_path_win}}"
+    type: string

--- a/deployments/ansible/roles/collector/tasks/win_fluent_install.yml
+++ b/deployments/ansible/roles/collector/tasks/win_fluent_install.yml
@@ -1,0 +1,33 @@
+---
+
+# Download and Install FluentD for Windows
+
+- name: Download Fluentd for windows
+  ansible.windows.win_get_url:
+    url: "{{td_agent_base_url}}/4/windows/{{win_fluentd_msi}}"
+    dest: C:\Users\td-agent-{{win_td_agent_version}}-x64.msi
+
+# Check for existing fluentd Installation
+
+- name: Check if splunk-otel-collector service is installed
+  ansible.windows.win_service:
+    name: fluentdwinsvc
+  register: service_info
+
+# Uninstall existing fluentd service
+
+- name: Delete previous splunk-otel-collector service if exist
+  ansible.windows.win_service:
+    name: fluentdwinsvc
+    state: absent
+  when: service_info.exists
+
+- name: install Fluentd for windows
+  ansible.windows.win_package:
+    path: C:\Users\td-agent-{{win_td_agent_version}}-x64.msi
+    state: present
+
+- name: Create directory structure
+  ansible.windows.win_file:
+    path: "{{collector_path_win}}\\fluentd\\conf.d"
+    state: directory

--- a/deployments/ansible/roles/collector/tasks/win_fluent_install.yml
+++ b/deployments/ansible/roles/collector/tasks/win_fluent_install.yml
@@ -5,7 +5,7 @@
 - name: Download Fluentd for windows
   ansible.windows.win_get_url:
     url: "{{td_agent_base_url}}/4/windows/{{win_fluentd_msi}}"
-    dest: C:\Users\td-agent-{{win_td_agent_version}}-x64.msi
+    dest: C:\Users\Temp\td-agent-{{win_td_agent_version}}-x64.msi
 
 # Check for existing fluentd Installation
 
@@ -24,7 +24,7 @@
 
 - name: install Fluentd for windows
   ansible.windows.win_package:
-    path: C:\Users\td-agent-{{win_td_agent_version}}-x64.msi
+    path: C:\Users\Temp\td-agent-{{win_td_agent_version}}-x64.msi
     state: present
 
 - name: Create directory structure

--- a/deployments/ansible/roles/collector/tasks/win_install.yml
+++ b/deployments/ansible/roles/collector/tasks/win_install.yml
@@ -1,0 +1,22 @@
+---
+
+# splunk-otel-collector and FluentD Windows installation using msi.
+
+- name: Set Windows packages sources
+  ansible.builtin.set_fact:
+    windows_base_url: https://dl.signalfx.com
+    win_otel_msi: splunk-otel-collector-{{win_otel_version}}-amd64.msi
+    td_agent_base_url: http://packages.treasuredata.com.s3.amazonaws.com
+    win_fluentd_msi: td-agent-{{win_td_agent_version}}-x64.msi
+
+- name: Install Splunk OpenTelemetry Collector with msi package manager for Windows
+  ansible.builtin.import_tasks: otel_win_install.yml
+  when: ansible_os_family == "Windows"
+
+- name: Set Windows Registry values
+  ansible.builtin.import_tasks: otel_win_reg.yml
+  when: ansible_os_family == "Windows"
+
+- name: Install Splunk OpenTelemetry Collector with yum package manager
+  ansible.builtin.import_tasks: win_fluent_install.yml
+  when: install_fluentd


### PR DESCRIPTION
Install splunk-otel-collector using Ansible for Windows following MSI installer approach. 

- Downloading and installing Splunk-otel collector and FluentD for Windows.
- Setting up appropriate Registry Values for Windows.
- Updated README.md.